### PR TITLE
Run rice embed-go before go build

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -5,6 +5,9 @@ WORKDIR /app
 RUN go get -u github.com/jstemmer/go-junit-report
 RUN go get -u github.com/GeertJohan/go.rice/rice
 COPY . .
+RUN go mod tidy
+RUN go mod vendor
+RUN rice embed-go
 RUN go build -tags netgo -ldflags '-extldflags "-static"'
 
 FROM debian:stable-slim


### PR DESCRIPTION
Fixes https://github.com/docker/build-push-action/issues/395

This had been working for me with manual builds on a machine that had `rice-box.go` present, but automated builds were creating a bad Docker image.