### PR TITLE
App waits for S3 service to be available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get install -y make gcc libc-de
 RUN go get -u github.com/jstemmer/go-junit-report
 RUN go get -u github.com/GeertJohan/go.rice/rice
 WORKDIR /app
+COPY wait-for-s3.sh .
 EXPOSE 8080
 CMD make run

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - "9000"
     ports:
       - "9000:9000"
-    entrypoint: ["minio", "server", "/data"]
+    entrypoint: [ "minio", "server", "/data" ]
     networks:
       - local
 
@@ -59,8 +59,7 @@ services:
       - s3
     networks:
       - local
-    entrypoint: ["make", "run"]
-
+    entrypoint: [ "./wait-for-s3.sh", "make", "run" ]
   #varnish:
   #  image: "varnish:stable"
   #  restart: "no"
@@ -74,4 +73,4 @@ services:
   #    - app
 
 networks:
-  local:
+  local: null

--- a/wait-for-s3.sh
+++ b/wait-for-s3.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+S3URL=storage:9000
+
+until curl -i -s $S3URL >/dev/null
+do
+  echo "Waiting for S3 service at $S3URL."
+  sleep 1
+done
+  
+echo "S3 service is available."
+exec "$@"


### PR DESCRIPTION
Hi!

I noticed that when running Docker Compose on my machine the main app was exiting because it didn't find the `storage` service.

![image](https://user-images.githubusercontent.com/6134409/144174214-53c57e5a-af1b-48e9-a7b7-665a922737a0.png)

Although the `docker-compose.yml` declares a dependency this does not guarantee that the `storage` service is actually _running_ in time.

I've added a simple script that waits to see that the S3 service is running before launching the app.

Thanks, Andrew.