### PR TITLE
Disable wait-for-s3 for the ci job

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -59,7 +59,7 @@ services:
       - s3
     networks:
       - local
-    entrypoint: [ "./wait-for-s3.sh", "make" ]
+    entrypoint: [ "make" ]
 
   #varnish:
   #  image: "varnish:stable"


### PR DESCRIPTION
For some reason it fails on CCI (can't resolve `storage`) and works on Github Actions. Removing it for now since I don't have time to debug atm.