### PR TITLE
Exposing the /metrics endpoint is now optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ darwin: prepare
 	GOOS=darwin GOARCH=amd64 go build -mod=vendor -o artifacts/filebin2-darwin-amd64 -trimpath -buildvcs=false
 
 run: linux
-	artifacts/filebin2-linux-amd64 --listen-host 0.0.0.0 --lurker-interval 10 --expiration 3600 --access-log=access.log --s3-secure=false --db-host=db --limit-storage 1G --admin-username admin --admin-password changeme --metrics-username metrics --metrics-password changemetoo
+	artifacts/filebin2-linux-amd64 --listen-host 0.0.0.0 --lurker-interval 10 --expiration 3600 --access-log=access.log --s3-secure=false --db-host=db --limit-storage 1G --admin-username admin --admin-password changeme --metrics
 
 fmt:
 	gofmt -w -s *.go

--- a/README.md
+++ b/README.md
@@ -141,6 +141,14 @@ The username used for authentication to the `/metrics` endpoint for Prometheus m
 
 The password used for authentication to the `/metrics` endpoint for Prometheus metrics. If the username is not set, this endpoint is disabled.
 
+#### `--metrics` (default: false)
+
+Enables the `/metrics` endpoint. If this is not set, the endpoint will not return any metrics.
+
+#### `--metrics-auth` (default: not set)
+
+Enables authentication. Currently only basic auth is supported. If `--metrics-auth` or (env) `METRICS_AUTH` is set to `basic` basic auth will be in play. If not, the endpoint is open to the world.
+
 #### `--metrics-id` (default: hostname)
 
 The string used as the identification of the filebin instance in the Prometheus metrics. By default, this string is the `$HOSTNAME` environment variable.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,9 @@ services:
       - S3_SECRET_KEY=s3secretkey
       - ADMIN_USERNAME=admin
       - ADMIN_PASSWORD=changeme
+      - METRICS_USERNAME=foo
+      - METRICS_PASSWORD=bar
+      - METRICS_AUTH=basic
     expose:
       - "8080"
     ports:

--- a/ds/config.go
+++ b/ds/config.go
@@ -19,6 +19,8 @@ type Config struct {
 	AdminPassword        string
 	MetricsUsername      string
 	MetricsPassword      string
+	Metrics              bool
+	MetricsAuth          string
 	MetricsProxyURL      string
 	SlackSecret          string
 	SlackDomain          string

--- a/main.go
+++ b/main.go
@@ -66,6 +66,8 @@ var (
 	adminPasswordFlag   = flag.String("admin-password", "", "Admin password")
 	metricsUsernameFlag = flag.String("metrics-username", "", "Metrics username")
 	metricsPasswordFlag = flag.String("metrics-password", "", "Metrics password")
+	metricsFlag   		= flag.Bool("metrics", false, "Enable the metrics endpoint")
+	metricsAuthFlag     = flag.String("metrics-auth", "", "Set the auth type for the metrics endpoint")
 	metricsIdFlag       = flag.String("metrics-id", os.Getenv("METRICS_ID"), "Metrics instance identification")
 	metricsProxyURLFlag = flag.String("metrics-proxy-url", "", "URL to another Prometheus exporter that we should proxy")
 
@@ -109,6 +111,9 @@ func main() {
 	}
 	if *metricsPasswordFlag == "" {
 		*metricsPasswordFlag = os.Getenv("METRICS_PASSWORD")
+	}
+	if *metricsAuthFlag == "" {
+		*metricsAuthFlag = os.Getenv("METRICS_AUTH")
 	}
 	if *slackSecretFlag == "" {
 		*slackSecretFlag = os.Getenv("SLACK_SECRET")
@@ -193,6 +198,8 @@ func main() {
 		AdminUsername:        *adminUsernameFlag,
 		MetricsPassword:      *metricsPasswordFlag,
 		MetricsUsername:      *metricsUsernameFlag,
+		Metrics:    	  	  *metricsFlag,
+		MetricsAuth:      	  *metricsAuthFlag,
 		MetricsProxyURL:      *metricsProxyURLFlag,
 		AllowRobots:          *allowRobotsFlag,
 		BaseUrl:              *u,


### PR DESCRIPTION
* /metrics endpoint can be exposed with the --metrics argument
* Basic auth is supported by adding the --metrics-auth basic argument
* Updated README