### PR TITLE
Add support for a wider set of characters in filenames

### DIFF
--- a/dbl/file.go
+++ b/dbl/file.go
@@ -79,6 +79,13 @@ func (d *FileDao) ValidateInput(file *ds.File) error {
 		n = strings.Replace(n, ".", "_", 1)
 	}
 
+	// Truncate long filenames
+	// XXX: The maximum length could be made configurable
+	if len(n) > 120 {
+		fmt.Printf("Truncating filename to 120 characters. Counting %d characters in %q.\n", len(n), n)
+		n = n[:120]
+	}
+
 	if file.Filename != n {
 		fmt.Printf("Modifying filename during upload from %q to %q\n", file.Filename, n)
 	}

--- a/dbl/file.go
+++ b/dbl/file.go
@@ -10,11 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
-	//"regexp"
 	"unicode"
 )
-
-//var validCharacters = regexp.MustCompile("-_=+,.")
 
 type FileDao struct {
 	db *sql.DB
@@ -31,14 +28,15 @@ func setCategory(file *ds.File) {
 }
 
 func (d *FileDao) ValidateInput(file *ds.File) error {
-	// Trim whitespace before and after.
+	// Trim whitespace before and after the filename.
 	file.Filename = strings.TrimSpace(file.Filename)
 
-	// If the filename is empty, error out
+	// If the filename is empty, error out.
 	if len(file.Filename) == 0 {
 		return errors.New("Filename not specified")
 	}
 
+	// Create a new variable to use for filename modifications.
 	n := file.Filename
 
 	// Extract the basename from the filename, in case the filename
@@ -87,7 +85,9 @@ func (d *FileDao) ValidateInput(file *ds.File) error {
 	}
 
 	if file.Filename != n {
+		// Log that the filename was modified.
 		fmt.Printf("Modifying filename during upload from %q to %q\n", file.Filename, n)
+
 	}
 
 	file.Filename = n

--- a/dbl/file.go
+++ b/dbl/file.go
@@ -3,14 +3,18 @@ package dbl
 import (
 	"database/sql"
 	"errors"
-	//"fmt"
+	"fmt"
 	"github.com/dustin/go-humanize"
 	"github.com/espebra/filebin2/ds"
 	"path"
 	"path/filepath"
 	"strings"
 	"time"
+	//"regexp"
+	"unicode"
 )
+
+//var validCharacters = regexp.MustCompile("-_=+,.")
 
 type FileDao struct {
 	db *sql.DB
@@ -27,27 +31,59 @@ func setCategory(file *ds.File) {
 }
 
 func (d *FileDao) ValidateInput(file *ds.File) error {
-	// Verify that the filename provided is a clean filename and not a
-	// folder structure.
-	if file.Filename != filepath.Base(file.Filename) {
-		return errors.New("The filename specified is not a clean basename")
-	}
-
-	// Replace all invalid UTF-8 characters in the filename with _
-	file.Filename = strings.ToValidUTF8(file.Filename, "_")
-
 	// Trim whitespace before and after.
 	file.Filename = strings.Trim(file.Filename, " ")
-
-	// . is not allowed as the first character
-	if strings.HasPrefix(file.Filename, ".") {
-		file.Filename = strings.Replace(file.Filename, ".", "_", 1)
-	}
 
 	// If the filename is empty, error out
 	if len(file.Filename) == 0 {
 		return errors.New("Filename not specified")
 	}
+
+	n := file.Filename
+
+	// Extract the basename from the filename, in case the filename
+	// is not clean and contains a folder structure.
+	// folder structure.
+	n = filepath.Base(n)
+
+	// Replace all invalid UTF-8 characters in the filename with _
+	n = strings.ToValidUTF8(n, "_")
+
+	// Mapping function to replace non-safe characters with underscore.
+	// It is possible that this filter can be extended to allow more
+	// unicode categories.
+	safe := func(r rune) rune {
+		switch {
+		// Allow numbers
+		case unicode.IsNumber(r):
+			//fmt.Printf("Character check: r=%q is a number\n", r)
+			return r
+		// Allow letters
+		case unicode.IsLetter(r):
+			//fmt.Printf("Character check: r=%q is a letter\n", r)
+			return r
+		// Allow certain other characters
+		case strings.ContainsAny(string(r), "-_=+,."):
+			//fmt.Printf("Character check: r=%q is a valid character\n", r)
+			return r
+		}
+		//fmt.Printf("Invalid character (%q) in filename replaced with underscore\n", r)
+		// All other characters are replaced with an underscore
+		return '_'
+
+	}
+	n = strings.Map(safe, n)
+
+	// . is not allowed as the first character
+	if strings.HasPrefix(n, ".") {
+		n = strings.Replace(n, ".", "_", 1)
+	}
+
+	if file.Filename != n {
+		fmt.Printf("Modifying filename during upload from %q to %q\n", file.Filename, n)
+	}
+
+	file.Filename = n
 
 	return nil
 }

--- a/dbl/file.go
+++ b/dbl/file.go
@@ -32,7 +32,7 @@ func setCategory(file *ds.File) {
 
 func (d *FileDao) ValidateInput(file *ds.File) error {
 	// Trim whitespace before and after.
-	file.Filename = strings.Trim(file.Filename, " ")
+	file.Filename = strings.TrimSpace(file.Filename)
 
 	// If the filename is empty, error out
 	if len(file.Filename) == 0 {

--- a/dbl/file_test.go
+++ b/dbl/file_test.go
@@ -502,3 +502,58 @@ func TestInvalidFileInput(t *testing.T) {
 		t.Error("Expected an error since filename is not set")
 	}
 }
+
+func TestUpsertWiderCharacterSet(t *testing.T) {
+	dao, err := tearUp()
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	defer tearDown(dao)
+
+	// Create bin first
+	bin := &ds.Bin{}
+	bin.Id = "sometestbin"
+	err = dao.Bin().Upsert(bin)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Create file
+	file := &ds.File{}
+	file.Filename = "ОДД.txt"
+	file.Bin = bin.Id // Foreign key
+	file.Bytes = 1
+	file.SHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	file.InStorage = true
+
+	err = dao.File().Insert(file)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if file.Id == 0 {
+		t.Error(errors.New("Expected id > 0"))
+	}
+
+	// Create file2
+	file2 := &ds.File{}
+	file2.Filename = "雨中.txt"
+	file2.Bin = bin.Id // Foreign key
+	file2.Bytes = 1
+	file2.SHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	file2.InStorage = true
+
+	err = dao.File().Insert(file2)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if file2.Id == 0 {
+		t.Error(errors.New("Expected id > 0"))
+	}
+}

--- a/dbl/file_test.go
+++ b/dbl/file_test.go
@@ -551,6 +551,14 @@ func TestUpsertWiderCharacterSet(t *testing.T) {
 			InputFilename:    "℃!",
 			Valid:            true,
 			ModifiedFilename: "__",
+		}, {
+			InputFilename:    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			Valid:            true,
+			ModifiedFilename: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		}, {
+			InputFilename:    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			Valid:            true,
+			ModifiedFilename: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 		},
 	}
 

--- a/http_bin.go
+++ b/http_bin.go
@@ -359,7 +359,7 @@ func (h *HTTP) archive(w http.ResponseWriter, r *http.Request) {
 				fmt.Println(err)
 			}
 			h.metrics.IncrBytesFilebinToClient(uint64(bytes))
-			fmt.Printf("Added file %s at %s (%d bytes) to the tar archive for bin %s\n", file.Filename, humanize.Bytes(uint64(bytes)), bytes, bin.Id)
+			fmt.Printf("Added file %q at %s (%d bytes) to the tar archive for bin %s\n", file.Filename, humanize.Bytes(uint64(bytes)), bytes, bin.Id)
 		}
 		if err := tw.Close(); err != nil {
 			fmt.Println(err)

--- a/http_bin.go
+++ b/http_bin.go
@@ -320,7 +320,7 @@ func (h *HTTP) archive(w http.ResponseWriter, r *http.Request) {
 				fmt.Println(err)
 			}
 			h.metrics.IncrBytesFilebinToClient(uint64(bytes))
-			fmt.Printf("Added file %s at %s (%d bytes) to the zip archive for bin %s\n", file.Filename, humanize.Bytes(uint64(bytes)), bytes, bin.Id)
+			fmt.Printf("Added file %q at %s (%d bytes) to the zip archive for bin %s\n", file.Filename, humanize.Bytes(uint64(bytes)), bytes, bin.Id)
 		}
 		if err := zw.Close(); err != nil {
 			fmt.Println(err)

--- a/static/js/filebin2.js
+++ b/static/js/filebin2.js
@@ -285,7 +285,8 @@ function FileAPI (c, t, d, f, bin, binURL) {
                 updateFileCount();
             };
 
-            filename = file.name.replace(/[^A-Za-z0-9-_=,.]/g, "_");
+            // XXX: Consider validating UTF-8 here
+            filename = file.name;
 
             // XXX: Do this properly using a path join function
             uploadURL = "/" + bin + "/" + filename;
@@ -297,7 +298,6 @@ function FileAPI (c, t, d, f, bin, binURL) {
             );
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest");
-            xhr.setRequestHeader("Filename", filename);
             xhr.setRequestHeader("Size", file.size);
             xhr.setRequestHeader("Bin", bin);
             xhr.send(file);


### PR DESCRIPTION
This patch will basically allow any valid utf-8 strings as filenames, with some exceptions to make the filenames safe.

Addressing issue https://github.com/espebra/filebin2/issues/38.