### PR TITLE
Potential fix for code scanning alert no. 86: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ '*' ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/espebra/filebin2/security/code-scanning/86](https://github.com/espebra/filebin2/security/code-scanning/86)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly set the permissions for the `GITHUB_TOKEN` to `contents: read`, which is sufficient for the tasks performed in the workflow (e.g., checking out code and fetching dependencies). This change ensures that the workflow does not have unnecessary write permissions, reducing the risk of unintended or malicious actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
