### PR TITLE
Make Errno codes in web handlers unique

### DIFF
--- a/internal/web/http_admin.go
+++ b/internal/web/http_admin.go
@@ -157,7 +157,7 @@ func (h *HTTP) viewAdminClientUploadFailures(w http.ResponseWriter, r *http.Requ
 		out, err := json.MarshalIndent(data, "", "    ")
 		if err != nil {
 			slog.Error("failed to parse json", "error", err)
-			http.Error(w, "Errno 201", http.StatusInternalServerError)
+			http.Error(w, "Errno 220", http.StatusInternalServerError)
 			return
 		}
 		w.WriteHeader(200)
@@ -216,7 +216,7 @@ func (h *HTTP) viewAdminClientUploadSuccesses(w http.ResponseWriter, r *http.Req
 		out, err := json.MarshalIndent(data, "", "    ")
 		if err != nil {
 			slog.Error("failed to parse json", "error", err)
-			http.Error(w, "Errno 201", http.StatusInternalServerError)
+			http.Error(w, "Errno 221", http.StatusInternalServerError)
 			return
 		}
 		w.WriteHeader(200)
@@ -317,7 +317,7 @@ func (h *HTTP) viewAdminFiles(w http.ResponseWriter, r *http.Request) {
 		out, err := json.MarshalIndent(data, "", "    ")
 		if err != nil {
 			slog.Error("failed to parse json", "error", err)
-			http.Error(w, "Errno 201", http.StatusInternalServerError)
+			http.Error(w, "Errno 222", http.StatusInternalServerError)
 			return
 		}
 		w.WriteHeader(200)
@@ -325,7 +325,7 @@ func (h *HTTP) viewAdminFiles(w http.ResponseWriter, r *http.Request) {
 	} else {
 		if err := h.renderTemplate(w, "admin_files", data); err != nil {
 			slog.Error("failed to execute template", "error", err)
-			http.Error(w, "Errno 203", http.StatusInternalServerError)
+			http.Error(w, "Errno 223", http.StatusInternalServerError)
 			return
 		}
 	}
@@ -371,7 +371,7 @@ func (h *HTTP) viewAdminFileContent(w http.ResponseWriter, r *http.Request) {
 	contentByBytesEach, err := h.dao.File().FilesByBytes(limit)
 	if err != nil {
 		slog.Error("unable to get files by bytes", "error", err)
-		http.Error(w, "Errno 494", http.StatusInternalServerError)
+		http.Error(w, "Errno 224", http.StatusInternalServerError)
 		return
 	}
 
@@ -379,7 +379,7 @@ func (h *HTTP) viewAdminFileContent(w http.ResponseWriter, r *http.Request) {
 	contentByBytesTotal, err := h.dao.File().FilesByBytesTotal(limit)
 	if err != nil {
 		slog.Error("unable to get files by bytes total", "error", err)
-		http.Error(w, "Errno 495", http.StatusInternalServerError)
+		http.Error(w, "Errno 225", http.StatusInternalServerError)
 		return
 	}
 
@@ -387,7 +387,7 @@ func (h *HTTP) viewAdminFileContent(w http.ResponseWriter, r *http.Request) {
 	contentByCreated, err := h.dao.FileContent().GetByCreated(limit)
 	if err != nil {
 		slog.Error("unable to get by created", "error", err)
-		http.Error(w, "Errno 495", http.StatusInternalServerError)
+		http.Error(w, "Errno 226", http.StatusInternalServerError)
 		return
 	}
 
@@ -395,7 +395,7 @@ func (h *HTTP) viewAdminFileContent(w http.ResponseWriter, r *http.Request) {
 	blockedContent, err := h.dao.FileContent().GetBlocked(limit)
 	if err != nil {
 		slog.Error("unable to get blocked", "error", err)
-		http.Error(w, "Errno 496", http.StatusInternalServerError)
+		http.Error(w, "Errno 227", http.StatusInternalServerError)
 		return
 	}
 
@@ -413,7 +413,7 @@ func (h *HTTP) viewAdminFileContent(w http.ResponseWriter, r *http.Request) {
 		out, err := json.MarshalIndent(data, "", "    ")
 		if err != nil {
 			slog.Error("failed to parse json", "error", err)
-			http.Error(w, "Errno 201", http.StatusInternalServerError)
+			http.Error(w, "Errno 228", http.StatusInternalServerError)
 			return
 		}
 		w.WriteHeader(200)
@@ -421,7 +421,7 @@ func (h *HTTP) viewAdminFileContent(w http.ResponseWriter, r *http.Request) {
 	} else {
 		if err := h.renderTemplate(w, "admin_filecontent", data); err != nil {
 			slog.Error("failed to execute template", "error", err)
-			http.Error(w, "Errno 203", http.StatusInternalServerError)
+			http.Error(w, "Errno 229", http.StatusInternalServerError)
 			return
 		}
 	}
@@ -463,7 +463,7 @@ func (h *HTTP) viewAdminFile(w http.ResponseWriter, r *http.Request) {
 	fileByChecksum, err := h.dao.File().FileByChecksum(inputSHA256)
 	if err != nil {
 		slog.Error("unable to get file by checksum", "error", err)
-		http.Error(w, "Errno 494", http.StatusInternalServerError)
+		http.Error(w, "Errno 230", http.StatusInternalServerError)
 		return
 	}
 
@@ -474,7 +474,7 @@ func (h *HTTP) viewAdminFile(w http.ResponseWriter, r *http.Request) {
 		out, err := json.MarshalIndent(data, "", "    ")
 		if err != nil {
 			slog.Error("failed to parse json", "error", err)
-			http.Error(w, "Errno 201", http.StatusInternalServerError)
+			http.Error(w, "Errno 231", http.StatusInternalServerError)
 			return
 		}
 		w.WriteHeader(200)
@@ -482,7 +482,7 @@ func (h *HTTP) viewAdminFile(w http.ResponseWriter, r *http.Request) {
 	} else {
 		if err := h.renderTemplate(w, "admin_file_by_checksum", data); err != nil {
 			slog.Error("failed to execute template", "error", err)
-			http.Error(w, "Errno 203", http.StatusInternalServerError)
+			http.Error(w, "Errno 232", http.StatusInternalServerError)
 			return
 		}
 	}
@@ -585,7 +585,7 @@ func (h *HTTP) viewAdminRecentUploads(w http.ResponseWriter, r *http.Request) {
 		out, err := json.MarshalIndent(data, "", "    ")
 		if err != nil {
 			slog.Error("failed to parse json", "error", err)
-			http.Error(w, "Errno 201", http.StatusInternalServerError)
+			http.Error(w, "Errno 233", http.StatusInternalServerError)
 			return
 		}
 		w.WriteHeader(200)
@@ -593,7 +593,7 @@ func (h *HTTP) viewAdminRecentUploads(w http.ResponseWriter, r *http.Request) {
 	} else {
 		if err := h.renderTemplate(w, "admin_recent_uploads", data); err != nil {
 			slog.Error("failed to execute template", "error", err)
-			http.Error(w, "Errno 203", http.StatusInternalServerError)
+			http.Error(w, "Errno 234", http.StatusInternalServerError)
 			return
 		}
 	}
@@ -614,7 +614,7 @@ func (h *HTTP) viewAdminRecentUploadsText(w http.ResponseWriter, r *http.Request
 	files, err := h.dao.File().GetRecentUploads(mime, hours)
 	if err != nil {
 		slog.Error("unable to get recent uploads", "error", err)
-		http.Error(w, "Errno 501", http.StatusInternalServerError)
+		http.Error(w, "Errno 502", http.StatusInternalServerError)
 		return
 	}
 
@@ -656,7 +656,7 @@ func (h *HTTP) viewAdminBin(w http.ResponseWriter, r *http.Request) {
 	files, err := h.dao.File().GetByBinAll(inputBin)
 	if err != nil {
 		slog.Error("unable to get files by bin", "bin", inputBin, "error", err)
-		http.Error(w, "Errno 201", http.StatusInternalServerError)
+		http.Error(w, "Errno 235", http.StatusInternalServerError)
 		return
 	}
 	data.Files = files
@@ -674,7 +674,7 @@ func (h *HTTP) viewAdminBin(w http.ResponseWriter, r *http.Request) {
 	} else {
 		if err := h.renderTemplate(w, "admin_bin", data); err != nil {
 			slog.Error("failed to execute template", "error", err)
-			http.Error(w, "Errno 203", http.StatusInternalServerError)
+			http.Error(w, "Errno 236", http.StatusInternalServerError)
 			return
 		}
 	}
@@ -762,35 +762,35 @@ func (h *HTTP) viewAdminBins(w http.ResponseWriter, r *http.Request) {
 	binsByLastUpdated, err := h.dao.Bin().GetLastUpdated(limit)
 	if err != nil {
 		slog.Error("unable to get all", "error", err)
-		http.Error(w, "Errno 200", http.StatusInternalServerError)
+		http.Error(w, "Errno 237", http.StatusInternalServerError)
 		return
 	}
 
 	binsByBytes, err := h.dao.Bin().GetByBytes(limit)
 	if err != nil {
 		slog.Error("unable to get by bytes", "error", err)
-		http.Error(w, "Errno 200", http.StatusInternalServerError)
+		http.Error(w, "Errno 238", http.StatusInternalServerError)
 		return
 	}
 
 	binsByDownloads, err := h.dao.Bin().GetByDownloads(limit)
 	if err != nil {
 		slog.Error("unable to get by downloads", "error", err)
-		http.Error(w, "Errno 200", http.StatusInternalServerError)
+		http.Error(w, "Errno 239", http.StatusInternalServerError)
 		return
 	}
 
 	binsByFiles, err := h.dao.Bin().GetByFiles(limit)
 	if err != nil {
 		slog.Error("unable to get by files", "error", err)
-		http.Error(w, "Errno 200", http.StatusInternalServerError)
+		http.Error(w, "Errno 240", http.StatusInternalServerError)
 		return
 	}
 
 	binsByCreated, err := h.dao.Bin().GetByCreated(limit)
 	if err != nil {
 		slog.Error("unable to get by created", "error", err)
-		http.Error(w, "Errno 200", http.StatusInternalServerError)
+		http.Error(w, "Errno 241", http.StatusInternalServerError)
 		return
 	}
 
@@ -808,7 +808,7 @@ func (h *HTTP) viewAdminBins(w http.ResponseWriter, r *http.Request) {
 		out, err := json.MarshalIndent(data, "", "    ")
 		if err != nil {
 			slog.Error("failed to parse json", "error", err)
-			http.Error(w, "Errno 201", http.StatusInternalServerError)
+			http.Error(w, "Errno 242", http.StatusInternalServerError)
 			return
 		}
 		w.WriteHeader(200)
@@ -816,7 +816,7 @@ func (h *HTTP) viewAdminBins(w http.ResponseWriter, r *http.Request) {
 	} else {
 		if err := h.renderTemplate(w, "admin_bins", data); err != nil {
 			slog.Error("failed to execute template", "error", err)
-			http.Error(w, "Errno 203", http.StatusInternalServerError)
+			http.Error(w, "Errno 243", http.StatusInternalServerError)
 			return
 		}
 	}
@@ -838,7 +838,7 @@ func (h *HTTP) viewAdminBinsAll(w http.ResponseWriter, r *http.Request) {
 	binsAvailable, err := h.dao.Bin().GetAll()
 	if err != nil {
 		slog.Error("unable to get all", "error", err)
-		http.Error(w, "Errno 200", http.StatusInternalServerError)
+		http.Error(w, "Errno 244", http.StatusInternalServerError)
 		return
 	}
 
@@ -852,7 +852,7 @@ func (h *HTTP) viewAdminBinsAll(w http.ResponseWriter, r *http.Request) {
 		out, err := json.MarshalIndent(data, "", "    ")
 		if err != nil {
 			slog.Error("failed to parse json", "error", err)
-			http.Error(w, "Errno 201", http.StatusInternalServerError)
+			http.Error(w, "Errno 245", http.StatusInternalServerError)
 			return
 		}
 		w.WriteHeader(200)
@@ -860,7 +860,7 @@ func (h *HTTP) viewAdminBinsAll(w http.ResponseWriter, r *http.Request) {
 	} else {
 		if err := h.renderTemplate(w, "admin_bins_all", data); err != nil {
 			slog.Error("failed to execute template", "error", err)
-			http.Error(w, "Errno 203", http.StatusInternalServerError)
+			http.Error(w, "Errno 246", http.StatusInternalServerError)
 			return
 		}
 	}
@@ -886,7 +886,7 @@ func (h *HTTP) viewAdminLogBin(w http.ResponseWriter, r *http.Request) {
 
 	if err := h.renderTemplate(w, "log_bin", data); err != nil {
 		slog.Error("failed to execute template", "error", err)
-		http.Error(w, "Errno 203", http.StatusInternalServerError)
+		http.Error(w, "Errno 247", http.StatusInternalServerError)
 		return
 	}
 }
@@ -904,14 +904,14 @@ func (h *HTTP) viewAdminLogIP(w http.ResponseWriter, r *http.Request) {
 
 	trs, err := h.dao.Transaction().GetByIP(ip)
 	if err != nil {
-		http.Error(w, "Errno 361", http.StatusInternalServerError)
+		http.Error(w, "Errno 362", http.StatusInternalServerError)
 		return
 	}
 	data.Transactions = trs
 
 	if err := h.renderTemplate(w, "log_ip", data); err != nil {
 		slog.Error("failed to execute template", "error", err)
-		http.Error(w, "Errno 203", http.StatusInternalServerError)
+		http.Error(w, "Errno 248", http.StatusInternalServerError)
 		return
 	}
 }
@@ -950,56 +950,56 @@ func (h *HTTP) viewAdminClients(w http.ResponseWriter, r *http.Request) {
 	clientsByLastActiveAt, err := h.dao.Client().GetByLastActiveAt(limit)
 	if err != nil {
 		slog.Error("unable to get last active", "error", err)
-		http.Error(w, "Errno 200", http.StatusInternalServerError)
+		http.Error(w, "Errno 249", http.StatusInternalServerError)
 		return
 	}
 
 	clientsByRequests, err := h.dao.Client().GetByRequests(limit)
 	if err != nil {
 		slog.Error("unable to get by requests", "error", err)
-		http.Error(w, "Errno 200", http.StatusInternalServerError)
+		http.Error(w, "Errno 250", http.StatusInternalServerError)
 		return
 	}
 
 	clientsByBannedAt, err := h.dao.Client().GetByBannedAt(limit)
 	if err != nil {
 		slog.Error("unable to get by banned at", "error", err)
-		http.Error(w, "Errno 200", http.StatusInternalServerError)
+		http.Error(w, "Errno 251", http.StatusInternalServerError)
 		return
 	}
 
 	clientsByFilesUploaded, err := h.dao.Client().GetByFilesUploaded(limit)
 	if err != nil {
 		slog.Error("unable to get by files uploaded", "error", err)
-		http.Error(w, "Errno 200", http.StatusInternalServerError)
+		http.Error(w, "Errno 252", http.StatusInternalServerError)
 		return
 	}
 
 	clientsByBytesUploaded, err := h.dao.Client().GetByBytesUploaded(limit)
 	if err != nil {
 		slog.Error("unable to get by bytes uploaded", "error", err)
-		http.Error(w, "Errno 200", http.StatusInternalServerError)
+		http.Error(w, "Errno 253", http.StatusInternalServerError)
 		return
 	}
 
 	clientsByCountry, err := h.dao.Client().GetByCountry(limit)
 	if err != nil {
 		slog.Error("unable to get by country", "error", err)
-		http.Error(w, "Errno 200", http.StatusInternalServerError)
+		http.Error(w, "Errno 254", http.StatusInternalServerError)
 		return
 	}
 
 	clientsByNetwork, err := h.dao.Client().GetByNetwork(limit)
 	if err != nil {
 		slog.Error("unable to get by network", "error", err)
-		http.Error(w, "Errno 200", http.StatusInternalServerError)
+		http.Error(w, "Errno 255", http.StatusInternalServerError)
 		return
 	}
 
 	asnWithStats, err := h.dao.Client().GetASNWithStats(limit)
 	if err != nil {
 		slog.Error("unable to get ASN with stats", "error", err)
-		http.Error(w, "Errno 200", http.StatusInternalServerError)
+		http.Error(w, "Errno 256", http.StatusInternalServerError)
 		return
 	}
 
@@ -1020,7 +1020,7 @@ func (h *HTTP) viewAdminClients(w http.ResponseWriter, r *http.Request) {
 		out, err := json.MarshalIndent(data, "", "    ")
 		if err != nil {
 			slog.Error("failed to parse json", "error", err)
-			http.Error(w, "Errno 201", http.StatusInternalServerError)
+			http.Error(w, "Errno 257", http.StatusInternalServerError)
 			return
 		}
 		w.WriteHeader(200)
@@ -1028,7 +1028,7 @@ func (h *HTTP) viewAdminClients(w http.ResponseWriter, r *http.Request) {
 	} else {
 		if err := h.renderTemplate(w, "admin_clients", data); err != nil {
 			slog.Error("failed to execute template", "error", err)
-			http.Error(w, "Errno 203", http.StatusInternalServerError)
+			http.Error(w, "Errno 258", http.StatusInternalServerError)
 			return
 		}
 	}
@@ -1038,7 +1038,7 @@ func (h *HTTP) viewAdminClientsAll(w http.ResponseWriter, r *http.Request) {
 	clients, err := h.dao.Client().GetAll()
 	if err != nil {
 		slog.Error("unable to get all", "error", err)
-		http.Error(w, "Errno 200", http.StatusInternalServerError)
+		http.Error(w, "Errno 259", http.StatusInternalServerError)
 		return
 	}
 	type Data struct {
@@ -1053,7 +1053,7 @@ func (h *HTTP) viewAdminClientsAll(w http.ResponseWriter, r *http.Request) {
 		out, err := json.MarshalIndent(data, "", "    ")
 		if err != nil {
 			slog.Error("failed to parse json", "error", err)
-			http.Error(w, "Errno 201", http.StatusInternalServerError)
+			http.Error(w, "Errno 260", http.StatusInternalServerError)
 			return
 		}
 		w.WriteHeader(200)
@@ -1061,7 +1061,7 @@ func (h *HTTP) viewAdminClientsAll(w http.ResponseWriter, r *http.Request) {
 	} else {
 		if err := h.renderTemplate(w, "admin_clients_all", data); err != nil {
 			slog.Error("failed to execute template", "error", err)
-			http.Error(w, "Errno 203", http.StatusInternalServerError)
+			http.Error(w, "Errno 261", http.StatusInternalServerError)
 			return
 		}
 	}
@@ -1119,7 +1119,7 @@ func (h *HTTP) updateSiteMessage(w http.ResponseWriter, r *http.Request) {
 	}
 	if len(content) > 5000 {
 		slog.Warn("unable to update site message: content must be 5000 characters or less")
-		http.Error(w, "Errno 803", http.StatusBadRequest)
+		http.Error(w, "Errno 804", http.StatusBadRequest)
 		return
 	}
 

--- a/internal/web/http_bin.go
+++ b/internal/web/http_bin.go
@@ -73,7 +73,7 @@ func (h *HTTP) viewBin(w http.ResponseWriter, r *http.Request) {
 	bin, found, err := h.dao.Bin().GetByID(inputBin)
 	if err != nil {
 		slog.Error("unable to get bin by ID", "bin", inputBin, "error", err)
-		http.Error(w, "Errno 200", http.StatusInternalServerError)
+		http.Error(w, "Errno 262", http.StatusInternalServerError)
 		return
 	}
 	if found {
@@ -111,7 +111,7 @@ func (h *HTTP) viewBin(w http.ResponseWriter, r *http.Request) {
 		out, err := json.MarshalIndent(data, "", "    ")
 		if err != nil {
 			slog.Error("failed to parse json", "error", err)
-			http.Error(w, "Errno 201", http.StatusInternalServerError)
+			http.Error(w, "Errno 263", http.StatusInternalServerError)
 			return
 		}
 		w.WriteHeader(code)
@@ -143,7 +143,7 @@ func (h *HTTP) viewBinPlainText(w http.ResponseWriter, r *http.Request) {
 	bin, found, err := h.dao.Bin().GetByID(inputBin)
 	if err != nil {
 		slog.Error("unable to get bin by ID", "bin", inputBin, "error", err)
-		http.Error(w, "Errno 200", http.StatusInternalServerError)
+		http.Error(w, "Errno 264", http.StatusInternalServerError)
 		return
 	}
 	if found {
@@ -324,16 +324,16 @@ func (h *HTTP) archive(w http.ResponseWriter, r *http.Request) {
 	bin, found, err := h.dao.Bin().GetByID(inputBin)
 	if err != nil {
 		slog.Error("unable to get bin by ID", "bin", inputBin, "error", err)
-		http.Error(w, "Errno 200", http.StatusInternalServerError)
+		http.Error(w, "Errno 265", http.StatusInternalServerError)
 		return
 	}
 	if !found {
-		h.Error(w, r, "", "The bin does not exist.", 201, http.StatusNotFound)
+		h.Error(w, r, "", "The bin does not exist.", 266, http.StatusNotFound)
 		return
 	}
 
 	if !bin.IsReadable() {
-		h.Error(w, r, "", "This bin is no longer available.", 202, http.StatusNotFound)
+		h.Error(w, r, "", "This bin is no longer available.", 267, http.StatusNotFound)
 		return
 	}
 
@@ -511,7 +511,7 @@ func (h *HTTP) approveBin(w http.ResponseWriter, r *http.Request) {
 	bin, found, err := h.dao.Bin().GetByID(inputBin)
 	if err != nil {
 		slog.Error("unable to get bin by ID", "bin", inputBin, "error", err)
-		http.Error(w, "Errno 205", http.StatusInternalServerError)
+		http.Error(w, "Errno 206", http.StatusInternalServerError)
 		return
 	}
 	if !found {
@@ -554,7 +554,7 @@ func (h *HTTP) banBin(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(3 * time.Second)
 
 		slog.Error("unable to get bin by ID", "bin", inputBin, "error", err)
-		http.Error(w, "Errno 205", http.StatusInternalServerError)
+		http.Error(w, "Errno 207", http.StatusInternalServerError)
 		return
 	}
 	if !found {

--- a/internal/web/http_file.go
+++ b/internal/web/http_file.go
@@ -115,7 +115,7 @@ func (h *HTTP) getFile(w http.ResponseWriter, r *http.Request) {
 			data.NextUrl = nextUrl.String()
 			if err := h.renderTemplate(w, "cookie", data); err != nil {
 				slog.Error("failed to execute template", "error", err)
-				http.Error(w, "Errno 302", http.StatusInternalServerError)
+				http.Error(w, "Errno 303", http.StatusInternalServerError)
 				return
 			}
 			return
@@ -200,7 +200,7 @@ func (h *HTTP) uploadFile(w http.ResponseWriter, r *http.Request) {
 	// Check if bin exists
 	bin, found, err := h.dao.Bin().GetByID(inputBin)
 	if err != nil {
-		h.Error(w, r, fmt.Sprintf("Failed to select bin by id %q: %s", inputBin, err.Error()), "Database error", 112, http.StatusInternalServerError)
+		h.Error(w, r, fmt.Sprintf("Failed to select bin by id %q: %s", inputBin, err.Error()), "Database error", 128, http.StatusInternalServerError)
 		return
 	}
 
@@ -229,7 +229,7 @@ func (h *HTTP) uploadFile(w http.ResponseWriter, r *http.Request) {
 		}
 		bin, found, err = h.dao.Bin().GetByID(inputBin)
 		if err != nil || !found {
-			h.Error(w, r, fmt.Sprintf("Unable to fetch bin %q after insert: %s", inputBin, err), "Database error", 121, http.StatusInternalServerError)
+			h.Error(w, r, fmt.Sprintf("Unable to fetch bin %q after insert: %s", inputBin, err), "Database error", 137, http.StatusInternalServerError)
 			return
 		}
 		if inserted {
@@ -477,7 +477,7 @@ func (h *HTTP) uploadFile(w http.ResponseWriter, r *http.Request) {
 			file, _, err = h.dao.File().GetByName(bin.Id, inputFilename)
 			if err != nil {
 				slog.Error("unable to load file after insert conflict", "filename", inputFilename, "bin", bin.Id, "error", err)
-				http.Error(w, "Errno 108", http.StatusInternalServerError)
+				http.Error(w, "Errno 138", http.StatusInternalServerError)
 				return
 			}
 			file.SHA256 = sha256ChecksumString
@@ -487,7 +487,7 @@ func (h *HTTP) uploadFile(w http.ResponseWriter, r *http.Request) {
 			file.UploadDurationMs = time.Since(t0).Milliseconds()
 			if err := h.dao.File().Update(&file); err != nil {
 				slog.Error("unable to update file after insert conflict", "filename", file.Filename, "file_id", file.Id, "bin", bin.Id, "error", err)
-				http.Error(w, "Errno 108", http.StatusInternalServerError)
+				http.Error(w, "Errno 139", http.StatusInternalServerError)
 				return
 			}
 		}
@@ -542,7 +542,7 @@ func (h *HTTP) uploadFile(w http.ResponseWriter, r *http.Request) {
 	out, err := json.MarshalIndent(data, "", "    ")
 	if err != nil {
 		slog.Error("failed to parse json", "error", err)
-		http.Error(w, "Errno 201", http.StatusInternalServerError)
+		http.Error(w, "Errno 268", http.StatusInternalServerError)
 		return
 	}
 
@@ -573,7 +573,7 @@ func (h *HTTP) deleteFile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !bin.IsReadable() {
-		h.Error(w, r, "", "The bin is no longer available", 122, http.StatusNotFound)
+		h.Error(w, r, "", "The bin is no longer available", 140, http.StatusNotFound)
 		return
 	}
 

--- a/internal/web/http_index.go
+++ b/internal/web/http_index.go
@@ -54,7 +54,7 @@ func (h *HTTP) index(w http.ResponseWriter, r *http.Request) {
 
 	if err := h.renderTemplate(w, "index", data); err != nil {
 		slog.Error("failed to execute template", "error", err)
-		http.Error(w, "Errno 302", http.StatusInternalServerError)
+		http.Error(w, "Errno 304", http.StatusInternalServerError)
 		return
 	}
 }
@@ -73,7 +73,7 @@ func (h *HTTP) about(w http.ResponseWriter, r *http.Request) {
 
 	if err := h.renderTemplate(w, "about", data); err != nil {
 		slog.Error("failed to execute template", "error", err)
-		http.Error(w, "Errno 302", http.StatusInternalServerError)
+		http.Error(w, "Errno 305", http.StatusInternalServerError)
 		return
 	}
 }
@@ -97,7 +97,7 @@ func (h *HTTP) privacy(w http.ResponseWriter, r *http.Request) {
 
 	if err := h.renderTemplate(w, "privacy", data); err != nil {
 		slog.Error("failed to execute template", "error", err)
-		http.Error(w, "Errno 302", http.StatusInternalServerError)
+		http.Error(w, "Errno 306", http.StatusInternalServerError)
 		return
 	}
 }
@@ -116,7 +116,7 @@ func (h *HTTP) terms(w http.ResponseWriter, r *http.Request) {
 
 	if err := h.renderTemplate(w, "terms", data); err != nil {
 		slog.Error("failed to execute template", "error", err)
-		http.Error(w, "Errno 302", http.StatusInternalServerError)
+		http.Error(w, "Errno 307", http.StatusInternalServerError)
 		return
 	}
 }
@@ -135,7 +135,7 @@ func (h *HTTP) contact(w http.ResponseWriter, r *http.Request) {
 
 	if err := h.renderTemplate(w, "contact", data); err != nil {
 		slog.Error("failed to execute template", "error", err)
-		http.Error(w, "Errno 302", http.StatusInternalServerError)
+		http.Error(w, "Errno 308", http.StatusInternalServerError)
 		return
 	}
 }
@@ -153,7 +153,7 @@ func (h *HTTP) api(w http.ResponseWriter, r *http.Request) {
 
 	if err := h.renderTemplate(w, "api", data); err != nil {
 		slog.Error("failed to execute template", "error", err)
-		http.Error(w, "Errno 302", http.StatusInternalServerError)
+		http.Error(w, "Errno 309", http.StatusInternalServerError)
 		return
 	}
 }
@@ -173,7 +173,7 @@ func (h *HTTP) apiSpec(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/plain")
 	if err := h.renderTemplate(w, "apispec", data); err != nil {
 		slog.Error("failed to execute template", "error", err)
-		http.Error(w, "Errno 302", http.StatusInternalServerError)
+		http.Error(w, "Errno 310", http.StatusInternalServerError)
 		return
 	}
 }
@@ -211,7 +211,7 @@ func (h *HTTP) filebinStatus(w http.ResponseWriter, r *http.Request) {
 	out, err := json.MarshalIndent(data, "", "    ")
 	if err != nil {
 		slog.Error("failed to parse json", "error", err)
-		http.Error(w, "Errno 201", http.StatusInternalServerError)
+		http.Error(w, "Errno 269", http.StatusInternalServerError)
 		return
 	}
 	w.WriteHeader(code)
@@ -250,7 +250,7 @@ func (h *HTTP) storageStatus(w http.ResponseWriter, r *http.Request) {
 	out, err := json.MarshalIndent(data, "", "    ")
 	if err != nil {
 		slog.Error("failed to parse json", "error", err)
-		http.Error(w, "Errno 201", http.StatusInternalServerError)
+		http.Error(w, "Errno 270", http.StatusInternalServerError)
 		return
 	}
 	w.WriteHeader(code)
@@ -262,7 +262,7 @@ func (h *HTTP) robots(w http.ResponseWriter, r *http.Request) {
 
 	if err := h.renderTemplate(w, "robots", nil); err != nil {
 		slog.Error("failed to execute template", "error", err)
-		http.Error(w, "Errno 302", http.StatusInternalServerError)
+		http.Error(w, "Errno 311", http.StatusInternalServerError)
 		return
 	}
 }

--- a/internal/web/http_integration.go
+++ b/internal/web/http_integration.go
@@ -61,13 +61,13 @@ func (h *HTTP) integrationSlack(w http.ResponseWriter, r *http.Request) {
 
 	domain := r.PostFormValue("team_domain")
 	if h.config.SlackDomain != domain {
-		h.Error(w, r, fmt.Sprintf("Slack domain not correct: Got %q, requires %q\n", domain, h.config.SlackDomain), "Unauthorized", 835, http.StatusUnauthorized)
+		h.Error(w, r, fmt.Sprintf("Slack domain not correct: Got %q, requires %q\n", domain, h.config.SlackDomain), "Unauthorized", 837, http.StatusUnauthorized)
 		return
 	}
 
 	channel := r.PostFormValue("channel_name")
 	if h.config.SlackChannel != channel {
-		h.Error(w, r, fmt.Sprintf("Slack channel not correct: Got %q, requires %q\n", channel, h.config.SlackChannel), "Unauthorized", 835, http.StatusUnauthorized)
+		h.Error(w, r, fmt.Sprintf("Slack channel not correct: Got %q, requires %q\n", channel, h.config.SlackChannel), "Unauthorized", 838, http.StatusUnauthorized)
 		return
 	}
 
@@ -89,7 +89,7 @@ func (h *HTTP) integrationSlack(w http.ResponseWriter, r *http.Request) {
 				bin, found, err := h.dao.Bin().GetByID(inputBin)
 				if err != nil {
 					slog.Error("unable to get bin by ID", "bin", bin.Id, "error", err)
-					http.Error(w, "Errno 205", http.StatusInternalServerError)
+					http.Error(w, "Errno 208", http.StatusInternalServerError)
 					return
 				}
 				if !found {


### PR DESCRIPTION
Renumbers the `Errno NNN` codes returned by the web handlers so that each code is unique across the application. Previously several handlers reused the same Errno values, making it ambiguous which code path produced a given error.

No behavioral change beyond the error code strings — purely a renumbering for unambiguous diagnostics.

Files touched:
- `internal/web/http_admin.go`
- `internal/web/http_bin.go`
- `internal/web/http_file.go`
- `internal/web/http_index.go`
- `internal/web/http_integration.go`