### PR TITLE
Add HTTP endpoint to return SHA256 checksums

### DIFF
--- a/internal/web/http.go
+++ b/internal/web/http.go
@@ -254,6 +254,7 @@ func (h *HTTP) Init() error {
 	h.router.Handle("/static/{path:.*}", CacheControl(http.FileServer(http.FS(h.staticBox)))).Methods(http.MethodHead, http.MethodGet)
 	h.router.HandleFunc("/archive/{bin:[A-Za-z0-9_-]+}/{format:[a-z]+}", h.log(h.clientLookup(h.archive))).Methods(http.MethodHead, http.MethodGet)
 	h.router.HandleFunc("/{bin:[A-Za-z0-9_-]+}.txt", h.viewBinPlainText).Methods(http.MethodHead, http.MethodGet)
+	h.router.HandleFunc("/sha256/{bin:[A-Za-z0-9_-]+}", h.viewBinSha256).Methods(http.MethodHead, http.MethodGet)
 	h.router.HandleFunc("/qr/{bin:[A-Za-z0-9_-]+}", h.binQR).Methods(http.MethodHead, http.MethodGet)
 	h.router.HandleFunc("/{bin:[A-Za-z0-9_-]+}/", h.viewBinRedirect).Methods(http.MethodHead, http.MethodGet)
 	h.router.HandleFunc("/{bin:[A-Za-z0-9_-]+}", h.viewBin).Methods(http.MethodHead, http.MethodGet)

--- a/internal/web/http_bin.go
+++ b/internal/web/http_bin.go
@@ -183,6 +183,57 @@ func (h *HTTP) viewBinPlainText(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// viewBinSha256 lists the files in a bin along with their SHA256
+// checksums in plain text, formatted like the output of sha256sum(1):
+// the checksum, two spaces, then the filename, one file per line.
+func (h *HTTP) viewBinSha256(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "max-age=0")
+	w.Header().Set("X-Robots-Tag", "noindex")
+
+	params := mux.Vars(r)
+	inputBin := params["bin"]
+
+	var files []ds.File
+
+	bin, found, err := h.dao.Bin().GetByID(inputBin)
+	if err != nil {
+		slog.Error("unable to get bin by ID", "bin", inputBin, "error", err)
+		http.Error(w, "Errno 271", http.StatusInternalServerError)
+		return
+	}
+	if found {
+		fs, err := h.dao.File().GetByBin(inputBin, true)
+		if err != nil {
+			slog.Error("unable to get files by bin", "bin", inputBin, "error", err)
+			http.Error(w, "Not found", http.StatusNotFound)
+			return
+		}
+		if bin.IsReadable() {
+			files = fs
+		}
+	} else {
+		// Synthesize a bin without creating it. It will be created when a file is uploaded.
+		bin = ds.Bin{}
+		bin.Id = inputBin
+		bin.ExpiredAt = time.Now().UTC().Add(h.config.ExpirationDuration)
+		bin.ExpiredAtRelative = humanize.Time(bin.ExpiredAt)
+
+		// Intentional slowdown to make crawling less efficient
+		time.Sleep(1 * time.Second)
+	}
+
+	code := 200
+	if !bin.IsReadable() {
+		code = 404
+	}
+
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(code)
+	for _, file := range files {
+		_, _ = fmt.Fprintf(w, "%s  %s\n", file.SHA256, file.Filename)
+	}
+}
+
 func (h *HTTP) binQR(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "max-age=31536000")
 	w.Header().Set("X-Robots-Tag", "noindex")

--- a/internal/web/http_file_test.go
+++ b/internal/web/http_file_test.go
@@ -556,6 +556,48 @@ func TestBinText(t *testing.T) {
 	runTests(tcs, t)
 }
 
+func TestBinSha256(t *testing.T) {
+	tcs := []TestCase{
+		{
+			Description:   "Create new bin",
+			Method:        "POST",
+			Bin:           "mytestbin7",
+			Filename:      "a",
+			UploadContent: "content a",
+			StatusCode:    201,
+		}, {
+			Description:   "Upload second file",
+			Method:        "POST",
+			Bin:           "mytestbin7",
+			Filename:      "b",
+			UploadContent: "content b",
+			StatusCode:    201,
+		}, {
+			Description:     "Get bin sha256 checksums",
+			Method:          "GET",
+			Bin:             "sha256/mytestbin7",
+			DownloadContent: "0069ffe8481777aa403982d9e9b3fa48957015a07cfa0f66dae32050b95bda54  a\nc4363f384691f55ee5a5c315e1f7c37366ae232933665a93fe3bcc0d90bc937b  b\n",
+			StatusCode:      200,
+		}, {
+			Description: "Get sha256 checksums for non-existing bin",
+			Method:      "GET",
+			Bin:         "sha256/nosuchbin7",
+			StatusCode:  200,
+		}, {
+			Description: "Delete the bin",
+			Method:      "DELETE",
+			Bin:         "mytestbin7",
+			StatusCode:  200,
+		}, {
+			Description: "Get sha256 checksums for deleted bin",
+			Method:      "GET",
+			Bin:         "sha256/mytestbin7",
+			StatusCode:  404,
+		},
+	}
+	runTests(tcs, t)
+}
+
 func httpAdminRequest(method, path string) (statuscode int, body string, err error) {
 	u, err := url.Parse("http://localhost:8080")
 	if err != nil {


### PR DESCRIPTION
Adds an HTTP endpoint that returns the SHA256 checksums for the files in a bin.

Related to https://github.com/espebra/filebin2/issues/191

Files touched:
- `internal/web/http.go` — route registration
- `internal/web/http_bin.go` — handler implementation
- `internal/web/http_file_test.go` — tests